### PR TITLE
fix: use get fallback instead of Storage=0 retry

### DIFF
--- a/pkg/client/jetstream.go
+++ b/pkg/client/jetstream.go
@@ -22,6 +22,7 @@ package client
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -32,6 +33,24 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/propagation"
 )
+
+// jsErrCodeStorageTypeChange is the NATS JetStream error code returned when
+// attempting to change the storage type on an existing stream. Storage type
+// is immutable once a stream is created.
+const jsErrCodeStorageTypeChange = 10052
+
+// isStorageTypeError returns true if the error is a NATS API error indicating
+// that the storage type cannot be changed on an existing stream.
+func isStorageTypeError(
+	err error,
+) bool {
+	var apiErr *jetstream.APIError
+	if errors.As(err, &apiErr) {
+		return apiErr.ErrorCode == jsErrCodeStorageTypeChange
+	}
+
+	return false
+}
 
 // CreateOrUpdateStreamWithConfig creates or updates a JetStream stream with
 // the provided configuration.
@@ -55,16 +74,14 @@ func (c *Client) CreateOrUpdateStreamWithConfig(
 		return nil
 	}
 
-	if strings.Contains(err.Error(), "can not change storage type") {
+	// NATS does not allow changing the storage type on an existing
+	// stream (error 10052). The stream already exists, which is what
+	// we wanted — return success.
+	if isStorageTypeError(err) {
 		c.logger.Debug(
-			"retrying stream update without storage type",
+			"stream exists with different storage type, skipping update",
 			slog.String("name", streamConfig.Name),
 		)
-
-		streamConfig.Storage = 0
-		if _, retryErr := c.ExtJS.CreateOrUpdateStream(ctx, streamConfig); retryErr != nil {
-			return fmt.Errorf("error creating/updating stream %s: %w", streamConfig.Name, retryErr)
-		}
 
 		return nil
 	}

--- a/pkg/client/jetstream_public_test.go
+++ b/pkg/client/jetstream_public_test.go
@@ -94,7 +94,7 @@ func (s *JetStreamPublicTestSuite) TestCreateOrUpdateStreamWithConfig() {
 			expectedErr: "error creating/updating stream test-stream: stream creation failed",
 		},
 		{
-			name: "when storage type conflict retries without storage",
+			name: "when storage type conflict returns success",
 			config: jetstream.StreamConfig{
 				Name:    "test-stream",
 				Storage: jetstream.MemoryStorage,
@@ -102,32 +102,10 @@ func (s *JetStreamPublicTestSuite) TestCreateOrUpdateStreamWithConfig() {
 			mockSetup: func() {
 				s.mockExt.EXPECT().
 					CreateOrUpdateStream(gomock.Any(), gomock.Any()).
-					Return(nil, errors.New("stream configuration update can not change storage type")).
-					Times(1)
-				s.mockExt.EXPECT().
-					CreateOrUpdateStream(gomock.Any(), gomock.Any()).
-					Return(nil, nil).
+					Return(nil, &jetstream.APIError{Code: 500, ErrorCode: 10052, Description: "stream configuration update can not change storage type"}).
 					Times(1)
 			},
 			expectedErr: "",
-		},
-		{
-			name: "when storage type conflict and retry fails returns retry error",
-			config: jetstream.StreamConfig{
-				Name:    "test-stream",
-				Storage: jetstream.MemoryStorage,
-			},
-			mockSetup: func() {
-				s.mockExt.EXPECT().
-					CreateOrUpdateStream(gomock.Any(), gomock.Any()).
-					Return(nil, errors.New("stream configuration update can not change storage type")).
-					Times(1)
-				s.mockExt.EXPECT().
-					CreateOrUpdateStream(gomock.Any(), gomock.Any()).
-					Return(nil, errors.New("other error")).
-					Times(1)
-			},
-			expectedErr: "error creating/updating stream test-stream: other error",
 		},
 	}
 

--- a/pkg/client/kv.go
+++ b/pkg/client/kv.go
@@ -22,7 +22,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -62,19 +61,20 @@ func (c *Client) CreateOrUpdateKVBucketWithConfig(
 		return kv, nil
 	}
 
-	if strings.Contains(err.Error(), "can not change storage type") {
+	// NATS does not allow changing the storage type on an existing
+	// stream (error 10052). Fall back to returning the existing bucket.
+	if isStorageTypeError(err) {
 		c.logger.Debug(
-			"retrying KV bucket update without storage type",
+			"KV bucket exists with different storage type, returning existing",
 			slog.String("bucket", config.Bucket),
 		)
 
-		config.Storage = 0
-		kv, retryErr := c.ExtJS.CreateOrUpdateKeyValue(ctx, config)
-		if retryErr != nil {
+		kv, getErr := c.ExtJS.KeyValue(ctx, config.Bucket)
+		if getErr != nil {
 			return nil, fmt.Errorf(
 				"failed to create/update KV bucket %s: %w",
 				config.Bucket,
-				retryErr,
+				err,
 			)
 		}
 

--- a/pkg/client/kv_public_test.go
+++ b/pkg/client/kv_public_test.go
@@ -146,33 +146,25 @@ func (s *KVPublicTestSuite) TestCreateOrUpdateKVBucketWithConfig() {
 			expectedErr: "",
 		},
 		{
-			name: "when storage type conflict retries without storage",
+			name: "when storage type conflict returns existing bucket",
 			config: jetstream.KeyValueConfig{
 				Bucket:  "existing-bucket",
 				Storage: jetstream.MemoryStorage,
-				TTL:     1 * time.Hour,
 			},
 			mockSetup: func() {
 				s.mockExt.EXPECT().
-					CreateOrUpdateKeyValue(gomock.Any(), jetstream.KeyValueConfig{
-						Bucket:  "existing-bucket",
-						Storage: jetstream.MemoryStorage,
-						TTL:     1 * time.Hour,
-					}).
-					Return(nil, errors.New("stream configuration update can not change storage type")).
+					CreateOrUpdateKeyValue(gomock.Any(), gomock.Any()).
+					Return(nil, &jetstream.APIError{Code: 500, ErrorCode: 10052, Description: "stream configuration update can not change storage type"}).
 					Times(1)
 				s.mockExt.EXPECT().
-					CreateOrUpdateKeyValue(gomock.Any(), jetstream.KeyValueConfig{
-						Bucket: "existing-bucket",
-						TTL:    1 * time.Hour,
-					}).
+					KeyValue(gomock.Any(), "existing-bucket").
 					Return(s.mockKV, nil).
 					Times(1)
 			},
 			expectedErr: "",
 		},
 		{
-			name: "when storage type conflict and retry fails returns retry error",
+			name: "when storage type conflict and get fails returns original error",
 			config: jetstream.KeyValueConfig{
 				Bucket:  "bad-bucket",
 				Storage: jetstream.MemoryStorage,
@@ -180,14 +172,14 @@ func (s *KVPublicTestSuite) TestCreateOrUpdateKVBucketWithConfig() {
 			mockSetup: func() {
 				s.mockExt.EXPECT().
 					CreateOrUpdateKeyValue(gomock.Any(), gomock.Any()).
-					Return(nil, errors.New("stream configuration update can not change storage type")).
+					Return(nil, &jetstream.APIError{Code: 500, ErrorCode: 10052, Description: "stream configuration update can not change storage type"}).
 					Times(1)
 				s.mockExt.EXPECT().
-					CreateOrUpdateKeyValue(gomock.Any(), gomock.Any()).
-					Return(nil, errors.New("other error")).
+					KeyValue(gomock.Any(), "bad-bucket").
+					Return(nil, errors.New("bucket not found")).
 					Times(1)
 			},
-			expectedErr: "failed to create/update KV bucket bad-bucket: other error",
+			expectedErr: "failed to create/update KV bucket bad-bucket: nats: API error: code=500 err_code=10052 description=stream configuration update can not change storage type",
 		},
 		{
 			name: "error creating KV bucket with config",

--- a/pkg/client/objectstore.go
+++ b/pkg/client/objectstore.go
@@ -24,7 +24,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"strings"
 
 	"github.com/nats-io/nats.go/jetstream"
 )
@@ -49,19 +48,21 @@ func (c *Client) CreateOrUpdateObjectStore(
 		return os, nil
 	}
 
-	if strings.Contains(err.Error(), "can not change storage type") {
+	// NATS does not allow changing the storage type on an existing
+	// stream (error 10052). Fall back to returning the existing
+	// Object Store.
+	if isStorageTypeError(err) {
 		c.logger.Debug(
-			"retrying Object Store update without storage type",
+			"Object Store exists with different storage type, returning existing",
 			slog.String("bucket", cfg.Bucket),
 		)
 
-		cfg.Storage = 0
-		os, retryErr := c.ExtJS.CreateOrUpdateObjectStore(ctx, cfg)
-		if retryErr != nil {
+		os, getErr := c.ExtJS.ObjectStore(ctx, cfg.Bucket)
+		if getErr != nil {
 			return nil, fmt.Errorf(
 				"failed to create/update Object Store bucket %s: %w",
 				cfg.Bucket,
-				retryErr,
+				err,
 			)
 		}
 

--- a/pkg/client/objectstore_public_test.go
+++ b/pkg/client/objectstore_public_test.go
@@ -115,7 +115,7 @@ func (s *ObjectStorePublicTestSuite) TestCreateOrUpdateObjectStore() {
 			expectedErr: "",
 		},
 		{
-			name: "when storage type conflict retries without storage",
+			name: "when storage type conflict returns existing bucket",
 			config: jetstream.ObjectStoreConfig{
 				Bucket:  "existing-bucket",
 				Storage: jetstream.MemoryStorage,
@@ -123,17 +123,17 @@ func (s *ObjectStorePublicTestSuite) TestCreateOrUpdateObjectStore() {
 			mockSetup: func() {
 				s.mockExt.EXPECT().
 					CreateOrUpdateObjectStore(gomock.Any(), gomock.Any()).
-					Return(nil, errors.New("stream configuration update can not change storage type")).
+					Return(nil, &jetstream.APIError{Code: 500, ErrorCode: 10052, Description: "stream configuration update can not change storage type"}).
 					Times(1)
 				s.mockExt.EXPECT().
-					CreateOrUpdateObjectStore(gomock.Any(), gomock.Any()).
+					ObjectStore(gomock.Any(), "existing-bucket").
 					Return(s.mockObjStor, nil).
 					Times(1)
 			},
 			expectedErr: "",
 		},
 		{
-			name: "when storage type conflict and retry fails returns retry error",
+			name: "when storage type conflict and get fails returns original error",
 			config: jetstream.ObjectStoreConfig{
 				Bucket:  "bad-bucket",
 				Storage: jetstream.MemoryStorage,
@@ -141,14 +141,14 @@ func (s *ObjectStorePublicTestSuite) TestCreateOrUpdateObjectStore() {
 			mockSetup: func() {
 				s.mockExt.EXPECT().
 					CreateOrUpdateObjectStore(gomock.Any(), gomock.Any()).
-					Return(nil, errors.New("stream configuration update can not change storage type")).
+					Return(nil, &jetstream.APIError{Code: 500, ErrorCode: 10052, Description: "stream configuration update can not change storage type"}).
 					Times(1)
 				s.mockExt.EXPECT().
-					CreateOrUpdateObjectStore(gomock.Any(), gomock.Any()).
-					Return(nil, errors.New("other error")).
+					ObjectStore(gomock.Any(), "bad-bucket").
+					Return(nil, errors.New("bucket not found")).
 					Times(1)
 			},
-			expectedErr: "failed to create/update Object Store bucket bad-bucket: other error",
+			expectedErr: "failed to create/update Object Store bucket bad-bucket: nats: API error: code=500 err_code=10052 description=stream configuration update can not change storage type",
 		},
 		{
 			name: "error creating Object Store bucket",


### PR DESCRIPTION
## Summary

Fix the storage type conflict handling from PR #92. The previous
approach set `Storage = 0` on retry, but `FileStorage` is `iota`
(value 0) — so `Storage = 0` means `FileStorage`, not "don't change".

When a bucket was created with `memory` storage and the retry sent
`Storage = 0` (= `FileStorage`), NATS rejected it again.

## Fix

On storage type conflict:
- **KV buckets**: call `KeyValue(bucket)` to get the existing bucket
- **Object stores**: call `ObjectStore(bucket)` to get the existing store
- **Streams**: return nil (stream exists, which is what we wanted)

No retry with modified config — just accept that the resource exists.

🤖 Generated with [Claude Code](https://claude.ai/code)