### PR TITLE
feat: add core NATS Subscribe and PublishCore methods

### DIFF
--- a/pkg/client/connect_wrapper.go
+++ b/pkg/client/connect_wrapper.go
@@ -30,6 +30,7 @@ type NATSConnector interface {
 	Connect(url string, opts ...nats.Option) (*nats.Conn, error)
 	Subscribe(subject string, handler nats.MsgHandler) (*nats.Subscription, error)
 	QueueSubscribe(subject, queue string, handler nats.MsgHandler) (*nats.Subscription, error)
+	Publish(subject string, data []byte) error
 }
 
 // NATSConnWrapper is a concrete implementation of NATSConnector, wrapping a *nats.Conn.
@@ -83,4 +84,12 @@ func (n *NATSConnWrapper) QueueSubscribe(
 	handler nats.MsgHandler,
 ) (*nats.Subscription, error) {
 	return n.Conn.QueueSubscribe(subject, queue, handler)
+}
+
+// Publish wraps the core NATS Publish method of nats.Conn.
+func (n *NATSConnWrapper) Publish(
+	subject string,
+	data []byte,
+) error {
+	return n.Conn.Publish(subject, data)
 }

--- a/pkg/client/core.go
+++ b/pkg/client/core.go
@@ -1,0 +1,78 @@
+// Copyright (c) 2026 John Dewey
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+package client
+
+import (
+	"fmt"
+	"log/slog"
+
+	"github.com/nats-io/nats.go"
+)
+
+// Subscribe creates a core NATS subscription on the given subject.
+// Messages are delivered to the handler callback. This uses plain NATS
+// pub/sub (not JetStream) — suitable for fire-and-forget messaging
+// like enrollment requests and key rotation notifications.
+func (c *Client) Subscribe(
+	subject string,
+	handler nats.MsgHandler,
+) (*nats.Subscription, error) {
+	if c.NC == nil {
+		return nil, fmt.Errorf("NATS connection not established: call Connect() first")
+	}
+
+	c.logger.Debug(
+		"subscribing to subject",
+		slog.String("subject", subject),
+	)
+
+	sub, err := c.NC.Subscribe(subject, handler)
+	if err != nil {
+		return nil, fmt.Errorf("failed to subscribe to %s: %w", subject, err)
+	}
+
+	return sub, nil
+}
+
+// PublishCore publishes a message using core NATS (not JetStream).
+// Unlike Publish, this does not require JetStream stream routing and
+// does not inject OpenTelemetry trace headers. Use this for simple
+// fire-and-forget messaging like enrollment responses and key rotation.
+func (c *Client) PublishCore(
+	subject string,
+	data []byte,
+) error {
+	if c.NC == nil {
+		return fmt.Errorf("NATS connection not established: call Connect() first")
+	}
+
+	c.logger.Debug(
+		"publishing core message",
+		slog.String("subject", subject),
+		slog.Int("data_size", len(data)),
+	)
+
+	if err := c.NC.Publish(subject, data); err != nil {
+		return fmt.Errorf("failed to publish to %s: %w", subject, err)
+	}
+
+	return nil
+}

--- a/pkg/client/core_public_test.go
+++ b/pkg/client/core_public_test.go
@@ -1,0 +1,185 @@
+// Copyright (c) 2026 John Dewey
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+package client_test
+
+import (
+	"errors"
+	"log/slog"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/nats-io/nats.go"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/osapi-io/nats-client/pkg/client"
+	"github.com/osapi-io/nats-client/pkg/client/mocks"
+)
+
+type CorePublicTestSuite struct {
+	suite.Suite
+
+	mockCtrl *gomock.Controller
+	mockNATS *mocks.MockNATSConnector
+	client   *client.Client
+}
+
+func (s *CorePublicTestSuite) SetupTest() {
+	s.mockCtrl = gomock.NewController(s.T())
+	s.mockNATS = mocks.NewMockNATSConnector(s.mockCtrl)
+	s.client = client.New(slog.Default(), &client.Options{
+		Host: "localhost",
+		Port: 4222,
+		Auth: client.AuthOptions{
+			AuthType: client.NoAuth,
+		},
+	})
+	s.client.NC = s.mockNATS
+}
+
+func (s *CorePublicTestSuite) TearDownTest() {
+	s.mockCtrl.Finish()
+}
+
+func (s *CorePublicTestSuite) SetupSubTest() {
+	s.SetupTest()
+}
+
+func (s *CorePublicTestSuite) TestSubscribe() {
+	tests := []struct {
+		name        string
+		subject     string
+		setupMock   func()
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:    "when subscribe succeeds returns subscription",
+			subject: "test.subject",
+			setupMock: func() {
+				s.mockNATS.EXPECT().
+					Subscribe("test.subject", gomock.Any()).
+					Return(&nats.Subscription{}, nil)
+			},
+		},
+		{
+			name:    "when subscribe fails returns error",
+			subject: "test.subject",
+			setupMock: func() {
+				s.mockNATS.EXPECT().
+					Subscribe("test.subject", gomock.Any()).
+					Return(nil, errors.New("connection closed"))
+			},
+			wantErr:     true,
+			errContains: "failed to subscribe",
+		},
+		{
+			name:    "when NC is nil returns error",
+			subject: "test.subject",
+			setupMock: func() {
+				s.client.NC = nil
+			},
+			wantErr:     true,
+			errContains: "NATS connection not established",
+		},
+	}
+
+	for _, tt := range tests {
+		s.Run(tt.name, func() {
+			tt.setupMock()
+
+			sub, err := s.client.Subscribe(tt.subject, func(_ *nats.Msg) {})
+
+			if tt.wantErr {
+				s.Error(err)
+				s.Contains(err.Error(), tt.errContains)
+				s.Nil(sub)
+			} else {
+				s.NoError(err)
+				s.NotNil(sub)
+			}
+		})
+	}
+}
+
+func (s *CorePublicTestSuite) TestPublishCore() {
+	tests := []struct {
+		name        string
+		subject     string
+		data        []byte
+		setupClient func()
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:    "when publish succeeds",
+			subject: "test.subject",
+			data:    []byte("test data"),
+			setupClient: func() {
+				s.mockNATS.EXPECT().
+					Publish("test.subject", []byte("test data")).
+					Return(nil)
+			},
+		},
+		{
+			name:    "when publish fails returns error",
+			subject: "test.subject",
+			data:    []byte("test data"),
+			setupClient: func() {
+				s.mockNATS.EXPECT().
+					Publish("test.subject", []byte("test data")).
+					Return(errors.New("connection closed"))
+			},
+			wantErr:     true,
+			errContains: "failed to publish",
+		},
+		{
+			name:    "when NC is nil returns error",
+			subject: "test.subject",
+			data:    []byte("test data"),
+			setupClient: func() {
+				s.client.NC = nil
+			},
+			wantErr:     true,
+			errContains: "NATS connection not established",
+		},
+	}
+
+	for _, tt := range tests {
+		s.Run(tt.name, func() {
+			if tt.setupClient != nil {
+				tt.setupClient()
+			}
+
+			err := s.client.PublishCore(tt.subject, tt.data)
+
+			if tt.wantErr {
+				s.Error(err)
+				s.Contains(err.Error(), tt.errContains)
+			} else {
+				s.NoError(err)
+			}
+		})
+	}
+}
+
+func TestCorePublicTestSuite(t *testing.T) {
+	suite.Run(t, new(CorePublicTestSuite))
+}

--- a/pkg/client/mocks/nats_connector.gen.go
+++ b/pkg/client/mocks/nats_connector.gen.go
@@ -99,6 +99,20 @@ func (mr *MockNATSConnectorMockRecorder) JetStream(arg0 ...interface{}) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "JetStream", reflect.TypeOf((*MockNATSConnector)(nil).JetStream), arg0...)
 }
 
+// Publish mocks base method.
+func (m *MockNATSConnector) Publish(arg0 string, arg1 []byte) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Publish", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Publish indicates an expected call of Publish.
+func (mr *MockNATSConnectorMockRecorder) Publish(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Publish", reflect.TypeOf((*MockNATSConnector)(nil).Publish), arg0, arg1)
+}
+
 // QueueSubscribe mocks base method.
 func (m *MockNATSConnector) QueueSubscribe(arg0, arg1 string, arg2 nats.MsgHandler) (*nats.Subscription, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
## Summary

- Add `Subscribe(subject, handler)` — core NATS subscribe with callback
- Add `PublishCore(subject, data)` — core NATS publish without JetStream
- Add `Publish(subject, data)` to `NATSConnector` interface and wrapper

These support fire-and-forget messaging (enrollment, key rotation) that
doesn't need JetStream stream persistence. 100% test coverage.

## Test plan

- [ ] `go test -cover ./pkg/client/...` passes with 100% on core.go

🤖 Generated with [Claude Code](https://claude.ai/code)