### PR TITLE
chore: declare just in .mise.toml

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,4 +1,5 @@
 [tools]
 go = "1.25"
+just = "1.58.0"
 node = "22"
 bun = "latest"

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,5 +1,5 @@
 [tools]
 go = "1.25"
-just = "1.58.0"
+just = "latest"
 node = "22"
 bun = "latest"


### PR DESCRIPTION
`just` was not declared in `.mise.toml`, so `mise` had nothing to resolve and the
shell fell through to whatever was installed — Homebrew **1.45.0** here, while CI
installs **1.58.0** via `extractions/setup-just`.

The two disagree about formatting:

```
1.45   → set allow-duplicate-variables := true
1.58   → set allow-duplicate-variables
```

Each rejects the other's form, so a justfile formatted locally fails the check in
CI on a file nobody touched.

## Declared as `latest`, not pinned

Nothing maintains a pin in `.mise.toml` — `dependabot.yml` covers
`github-actions`, `gomod`, and `npm`, and no ecosystem watches mise. The workflow
setup action floats too. Pinning here while CI floats would guarantee divergence
at the next release.

Both resolve to **1.58.0** today and move together from here. `specs` and
`osapi-justfiles` already worked this way, and are the two that never diverged.

Verified: `mise exec -- just` gives 1.58.0, and this repository's justfiles pass
its format check under it.

Applies `standardize-repository-layout` task 5.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)