### PR TITLE
chore: normalize workflow names

### DIFF
--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -1,4 +1,4 @@
-name: Conventional Commits
+name: Commit Lint
 on:
   pull_request:
     branches: [ "main" ]

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,5 +1,5 @@
 ---
-name: "Pull Request Labeler"
+name: Labeler
 on:
   - pull_request_target
 

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,5 +1,5 @@
 ---
-name: Mark stale issues and pull requests
+name: Stale
 
 on:
   schedule:


### PR DESCRIPTION
Applies `specify-workflow-naming` tasks 3.a–3.c from [osapi-io/specs](https://github.com/osapi-io/specs).

| File | Was | Now |
| --- | --- | --- |
| `stale.yml` | `Mark stale issues and pull requests` | `Stale` |
| `labeler.yml` | `Pull Request Labeler` | `Labeler` |
| `commit-lint.yml` | `Conventional Commits` | `Commit Lint` |

The first was a sentence where every other workflow is a short title. The third named a standard rather than the subject — the check is that commits lint, and Conventional Commits is how.

Names now match their file, in title case, across all seven repositories.

🤖 Generated with [Claude Code](https://claude.com/claude-code)