### PR TITLE
chore: unquote the workflow name

### DIFF
--- a/.github/workflows/dep-review.yml
+++ b/.github/workflows/dep-review.yml
@@ -1,5 +1,5 @@
 ---
-name: 'Dependency Review'
+name: Dependency Review
 on: [pull_request]
 
 permissions:
@@ -11,5 +11,5 @@ jobs:
     steps:
       - name: 'Checkout Repository'
         uses: actions/checkout@v7
-      - name: 'Dependency Review'
+      - name: Dependency Review
         uses: actions/dependency-review-action@v5


### PR DESCRIPTION
`dep-review.yml` was the only workflow whose `name` was quoted:

```yaml
name: 'Dependency Review'   →   name: Dependency Review
```

The value was already title case; the quoting was the inconsistency. Found running `specify-workflow-naming` verification 4.0 across all seven repositories.

🤖 Generated with [Claude Code](https://claude.com/claude-code)